### PR TITLE
Fix black line on Firefox 72 Linux

### DIFF
--- a/sliding-bookmarks-bar.css
+++ b/sliding-bookmarks-bar.css
@@ -8,15 +8,15 @@
 
 #PersonalToolbar:not([customizing]) {
    position: fixed !important;
-   margin-top: -29px !important;
+   margin-top: -33px !important;
    padding-top: 4px !important;
    padding-bottom: 5px !important;
    height: auto !important;
    width: 100% !important;
- 
-   border: none !important; 
+
+   border: none !important;
    box-shadow: 0 1px 0 0 rgba(0,0,0,0.3);
-   
+
    transform: scaleY(0.8);
    transform-origin: center bottom;
    transition: transform cubic-bezier(.22,.61,.36,1) 0.15s !important;
@@ -35,13 +35,13 @@
 .tabbrowser-tab[selected="true"] {
    z-index: 4 !important;
 }
-#navigator-toolbox:hover #nav-bar:not([customizing]) { 
+#navigator-toolbox:hover #nav-bar:not([customizing]) {
 
 }
 
 #navigator-toolbox:hover > #PersonalToolbar:not([customizing]) {
    position: fixed !important;
-   
+
    transform: translateY(100%) scaleY(1);
 }
 
@@ -62,6 +62,7 @@
 /* compact + titlebar active */
 :root[lwtheme="true"]:not([tabsintitlebar="true"])
 #nav-bar ~ #PersonalToolbar:not([customizing]) {
+   margin-top: -30px;
    top: calc(var(--toolbar-offset-height) + 20px) !important;
 }
 


### PR DESCRIPTION
On ArchLinux, with Firefox 72b8 I get a black line if I use your sliding bookmark snippet.

Compact theme:
![screenshot-light](https://user-images.githubusercontent.com/1174685/71322156-d9884d80-24c4-11ea-8575-82343a386900.png)

Normal theme:
![screenshot-normal](https://user-images.githubusercontent.com/1174685/71322157-d9884d80-24c4-11ea-92ef-61fbf9f8e2dd.png)

I managed to fix that by increasing the offset of the margin-top, and setting a different value depending if the theme is normal or compact.